### PR TITLE
Fix hang on timeout

### DIFF
--- a/lib/HTTP/Server/Async.pm6
+++ b/lib/HTTP/Server/Async.pm6
@@ -40,7 +40,7 @@ class HTTP::Server::Async does HTTP::Server {
           CATCH { default { .say; } }
           try {
             $_<closedorclosing> = True;
-            $_<connection>.write(''); #https://irclog.perlgeek.de/perl6/2017-02-09#i_14073278
+            $_<connection>.write(Blob.new); #https://irclog.perlgeek.de/perl6/2017-02-09#i_14073278
             $_<connection>.close; 
           };
         }


### PR DESCRIPTION
`$_<connection>` wanted a `Blob` instead of a `Str`, and would throw an exception whether or not the connection was closed. This caused it to never close the connection, but still remove it from the `@!connects` array.